### PR TITLE
Twee aanpassingen om het nakijken nog iets te versimpelen

### DIFF
--- a/practicum_1_getallen_student.py
+++ b/practicum_1_getallen_student.py
@@ -344,7 +344,7 @@ def test_add_frac():
         my_assert_args(add_frac, case[0], case[1])
 
 
-if __name__ == '__main__':
+def main():
     try:
         print("\x1b[0;32m")
         test_id()
@@ -385,3 +385,6 @@ if __name__ == '__main__':
     except AssertionError as ae:
         print("\x1b[0;31m")
         print(ae)
+
+if __name__ == '__main__':
+    main()

--- a/practicum_2_algoritmiek_student.py
+++ b/practicum_2_algoritmiek_student.py
@@ -186,13 +186,6 @@ def test_binary_search_recursive():
             f"Fout: binary_search_recursive({lst_test}, {target}) geeft {outcome} in plaats van {found}"
         assert lst_copy == lst_test, "Fout: binary_search_recursive(lst, target) verandert de inhoud van lijst lst"
 
-def test_no_mutation():
-    for f_name, f in [("my_sort", my_sort),
-                      ("linear_search_recursive", lambda l: linear_search_recursive(l, 4)),
-                      ("binary_search_recursive", lambda l: binary_search_recursive(l, 4))]:
-        unsorted_lst = [4,2,5,1,3]
-        f(unsorted_lst)
-        assert unsorted_lst == [4,2,5,1,3], f"Fout: De functie {f_name}() past de input aan"
 
 def main():
     try:
@@ -208,14 +201,13 @@ def main():
         test_binary_search_recursive()
         print("Je functie binary_search_recursive() werkt goed!")
 
-        test_no_mutation()
-
         print("\nGefeliciteerd, alles lijkt te werken!")
         print("Lever je werk nu in op Canvas...")
 
     except AssertionError as ae:
         print("\x1b[0;31m")
         print(ae)
+
 
 if __name__ == '__main__':
     main()

--- a/practicum_2_algoritmiek_student.py
+++ b/practicum_2_algoritmiek_student.py
@@ -186,6 +186,14 @@ def test_binary_search_recursive():
             f"Fout: binary_search_recursive({lst_test}, {target}) geeft {outcome} in plaats van {found}"
         assert lst_copy == lst_test, "Fout: binary_search_recursive(lst, target) verandert de inhoud van lijst lst"
 
+def test_no_mutation():
+    for f_name, f in [("my_sort", my_sort),
+                      ("linear_search_recursive", lambda l: linear_search_recursive(l, 4)),
+                      ("binary_search_recursive", lambda l: binary_search_recursive(l, 4))]:
+        unsorted_lst = [4,2,5,1,3]
+        f(unsorted_lst)
+        assert unsorted_lst == [4,2,5,1,3], f"Fout: De functie {f_name}() past de input aan"
+
 def main():
     try:
         print("\x1b[0;32m")
@@ -199,6 +207,8 @@ def main():
 
         test_binary_search_recursive()
         print("Je functie binary_search_recursive() werkt goed!")
+
+        test_no_mutation()
 
         print("\nGefeliciteerd, alles lijkt te werken!")
         print("Lever je werk nu in op Canvas...")

--- a/practicum_2_algoritmiek_student.py
+++ b/practicum_2_algoritmiek_student.py
@@ -186,8 +186,7 @@ def test_binary_search_recursive():
             f"Fout: binary_search_recursive({lst_test}, {target}) geeft {outcome} in plaats van {found}"
         assert lst_copy == lst_test, "Fout: binary_search_recursive(lst, target) verandert de inhoud van lijst lst"
 
-
-if __name__ == '__main__':
+def main():
     try:
         print("\x1b[0;32m")
         test_id()
@@ -207,3 +206,6 @@ if __name__ == '__main__':
     except AssertionError as ae:
         print("\x1b[0;31m")
         print(ae)
+
+if __name__ == '__main__':
+    main()

--- a/practicum_3_statistiek_student.py
+++ b/practicum_3_statistiek_student.py
@@ -248,6 +248,13 @@ def test_modes():
     for case in testcases:
         my_assert_args(modes, case[0], case[1])
 
+def test_no_mutation():
+    for f_name, f in [("mean", mean), ("rnge", rnge), ("median", median), ("q1", q1), ("q3", q3),
+                      ("var", var), ("std", std), ("freq", freq), ("modes", modes)]:
+        unsorted_lst = [4,2,5,1,3]
+        f(unsorted_lst)
+        assert unsorted_lst == [4,2,5,1,3], f"Fout: De functie {f_name}() past de input aan"
+
 def main():
     try:
         print("\x1b[0;32m")
@@ -279,6 +286,8 @@ def main():
 
         test_modes()
         print("Je functie modes(lst) werkt goed!")
+
+        test_no_mutation()
 
         print("\nGefeliciteerd, alles lijkt te werken!")
         print("Lever je werk nu in op Canvas...")

--- a/practicum_3_statistiek_student.py
+++ b/practicum_3_statistiek_student.py
@@ -248,12 +248,14 @@ def test_modes():
     for case in testcases:
         my_assert_args(modes, case[0], case[1])
 
+
 def test_no_mutation():
     for f_name, f in [("mean", mean), ("rnge", rnge), ("median", median), ("q1", q1), ("q3", q3),
                       ("var", var), ("std", std), ("freq", freq), ("modes", modes)]:
         unsorted_lst = [4,2,5,1,3]
         f(unsorted_lst)
         assert unsorted_lst == [4,2,5,1,3], f"Fout: De functie {f_name}() past de input aan"
+
 
 def main():
     try:
@@ -324,6 +326,7 @@ def main():
     except AssertionError as ae:
         print("\x1b[0;31m")
         print(ae)
+
 
 if __name__ == '__main__':
     main()

--- a/practicum_3_statistiek_student.py
+++ b/practicum_3_statistiek_student.py
@@ -248,8 +248,7 @@ def test_modes():
     for case in testcases:
         my_assert_args(modes, case[0], case[1])
 
-
-if __name__ == '__main__':
+def main():
     try:
         print("\x1b[0;32m")
         test_id()
@@ -316,3 +315,6 @@ if __name__ == '__main__':
     except AssertionError as ae:
         print("\x1b[0;31m")
         print(ae)
+
+if __name__ == '__main__':
+    main()

--- a/practicum_4_herkansing_student.py
+++ b/practicum_4_herkansing_student.py
@@ -183,6 +183,10 @@ def test_outliers():
     for case in testcases:
         my_assert_args(outliers, case[0], sorted(case[1]))
 
+    unsorted_lst = [4,2,5,1,3]
+    outliers(unsorted_lst)
+    assert unsorted_lst == [4,2,5,1,3], f"Fout: De functie outliers() past de input aan"
+
 
 def test_my_sort():
     lst_test = [random.choice(range(10)) for _ in range(10)]
@@ -208,7 +212,7 @@ def test_primes():
         my_assert_args(primes, case[0], sorted(case[1]))
 
 
-if __name__ == '__main__':
+def main():
     try:
         print("\x1b[0;32m")
         test_id()
@@ -222,9 +226,15 @@ if __name__ == '__main__':
         test_primes()
         print("Je functie primes() werkt goed!")
 
+        test_no_mutation()
+
         print("\nGefeliciteerd, alles lijkt te werken!")
         print("Lever je werk nu in op Canvas...")
 
     except AssertionError as ae:
         print("\x1b[0;31m")
         print(ae)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Tests zitten nu in een functie, die aangeroepen wordt als `__name__` gelijk aan `__main__` is. Dit zou in de meeste gevallen geen verschil moeten maken, maar maakt het nakijken in iPython shells / Jupyter Lab eenvoudiger omdat er nu een functie aangeroepen kan worden.
- Bij FA2 en FA3 is een test toegevoegd die studenten erop wijst dat de originele lijst wordt aangepast (bijvoorbeeld door sorteren) waar dit niet de bedoeling is.