### PR TITLE
update testraamwerk

### DIFF
--- a/practicum_1_getallen_student.py
+++ b/practicum_1_getallen_student.py
@@ -314,6 +314,22 @@ def test_is_prime():
         __my_assert_args(is_prime, case[0], case[1])
 
 
+
+def test_primes():
+    testcases = [
+        ((1,), []),
+        ((2,), []),
+        ((3,), [2]),
+        ((4,), [2, 3]),
+        ((5,), [2, 3]),
+        ((6,), [2, 3, 5]),
+        ((30,), [2, 3, 5, 7, 11, 13, 17, 19, 23, 29])
+    ]
+
+    for case in testcases:
+        __my_assert_args(primes, case[0], sorted(case[1]))
+
+
 def test_primefactors():
     testcases = [
         ((-1,), []),
@@ -329,21 +345,6 @@ def test_primefactors():
 
     for case in testcases:
         __my_assert_args(primefactors, case[0], sorted(case[1]))
-
-
-def test_primes():
-    testcases = [
-        ((1,), []),
-        ((2,), []),
-        ((3,), [2]),
-        ((4,), [2, 3]),
-        ((5,), [2, 3]),
-        ((6,), [2, 3, 5]),
-        ((30,), [2, 3, 5, 7, 11, 13, 17, 19, 23, 29])
-    ]
-
-    for case in testcases:
-        __my_assert_args(primes, case[0], sorted(case[1]))
 
 
 def test_gcd():

--- a/practicum_1_getallen_student.py
+++ b/practicum_1_getallen_student.py
@@ -435,11 +435,11 @@ def __main():
         test_is_prime()
         print("Je functie is_prime(n) werkt goed!")
 
-        test_primefactors()
-        print("Je functie primefactors(n) werkt goed!")
-
         test_primes()
         print("Je functie primes(num) werkt goed!")
+        
+        test_primefactors()
+        print("Je functie primefactors(n) werkt goed!")
 
         test_gcd()
         test_gcd_simulated()


### PR DESCRIPTION
test_primes voor test_primefactors gezet 
wanneer test_primes is gemaakt runt het testraamwerk niet omdat test_primefactors nog niet is gemaakt.
door de tests om te draaien kan je test_primes testen voordat je test_primefactors heb gemaakt