### PR TITLE
fixed unit tests if user code throws an AssertionError with no message

### DIFF
--- a/bonusvraag_vier_kwadraten_student.py
+++ b/bonusvraag_vier_kwadraten_student.py
@@ -84,4 +84,8 @@ if __name__ == '__main__':
 
     except AssertionError as ae:
         print("\x1b[31m")
-        print(ae)
+        if len(str(ae)) == 0:
+            print("Je code veroorzaakt een AssertionError!")
+            raise ae
+        else:
+            print(ae)

--- a/bonusvraag_vier_kwadraten_student.py
+++ b/bonusvraag_vier_kwadraten_student.py
@@ -89,3 +89,4 @@ if __name__ == '__main__':
             raise ae
         else:
             print(ae)
+        exit(1)

--- a/faculteit_student.py
+++ b/faculteit_student.py
@@ -57,3 +57,4 @@ if __name__ == '__main__':
             raise ae
         else:
             print(ae)
+        exit(1)

--- a/faculteit_student.py
+++ b/faculteit_student.py
@@ -52,4 +52,8 @@ if __name__ == '__main__':
 
     except AssertionError as ae:
         print("\x1b[31m")
-        print(ae)
+        if len(str(ae)) == 0:
+            print("Je code veroorzaakt een AssertionError!")
+            raise ae
+        else:
+            print(ae)

--- a/insertion_sort_student.py
+++ b/insertion_sort_student.py
@@ -108,4 +108,8 @@ if __name__ == '__main__':
 
     except AssertionError as ae:
         print("\x1b[31m")
-        print(str(ae))
+        if len(str(ae)) == 0:
+            print("Je code veroorzaakt een AssertionError!")
+            raise ae
+        else:
+            print(ae)

--- a/insertion_sort_student.py
+++ b/insertion_sort_student.py
@@ -113,3 +113,4 @@ if __name__ == '__main__':
             raise ae
         else:
             print(ae)
+        exit(1)

--- a/practicum_1_getallen_student.py
+++ b/practicum_1_getallen_student.py
@@ -456,7 +456,11 @@ def __main():
 
     except AssertionError as ae:
         print("\x1b[31m")   # Rode tekstkleur
-        print(ae)
+        if len(str(ae)) == 0:
+            print("Je code veroorzaakt een AssertionError!")
+            raise ae
+        else:
+            print(ae)
 
     print("\x1b[0m")    # Reset tekstkleur
 

--- a/practicum_1_getallen_student.py
+++ b/practicum_1_getallen_student.py
@@ -461,8 +461,7 @@ def __main():
             raise ae
         else:
             print(ae)
-
-    print("\x1b[0m")    # Reset tekstkleur
+        exit(1)
 
 
 if __name__ == '__main__':

--- a/practicum_2_algoritmiek_student.py
+++ b/practicum_2_algoritmiek_student.py
@@ -217,7 +217,11 @@ def __main():
 
     except AssertionError as ae:
         print("\x1b[31m")   # Rode tekstkleur
-        print(ae)
+        if len(str(ae)) == 0:
+            print("Je code veroorzaakt een AssertionError!")
+            raise ae
+        else:
+            print(ae)
 
     print("\x1b[0m")    # Reset tekstkleur
 

--- a/practicum_2_algoritmiek_student.py
+++ b/practicum_2_algoritmiek_student.py
@@ -222,8 +222,7 @@ def __main():
             raise ae
         else:
             print(ae)
-
-    print("\x1b[0m")    # Reset tekstkleur
+        exit(1)
 
 
 if __name__ == '__main__':

--- a/practicum_3_statistiek_student.py
+++ b/practicum_3_statistiek_student.py
@@ -424,7 +424,11 @@ def __main():
 
     except AssertionError as ae:
         print("\x1b[31m")   # Rode tekstkleur
-        print(ae)
+        if len(str(ae)) == 0:
+            print("Je code veroorzaakt een AssertionError!")
+            raise ae
+        else:
+            print(ae)
 
     print("\x1b[0m")    # Reset tekstkleur
 

--- a/practicum_3_statistiek_student.py
+++ b/practicum_3_statistiek_student.py
@@ -429,8 +429,7 @@ def __main():
             raise ae
         else:
             print(ae)
-
-    print("\x1b[0m")    # Reset tekstkleur
+        exit(1)
 
 
 if __name__ == '__main__':

--- a/practicum_4_herkansing_student.py
+++ b/practicum_4_herkansing_student.py
@@ -264,8 +264,7 @@ def __main():
             raise ae
         else:
             print(ae)
-
-    print("\x1b[0m")    # Reset tekstkleur
+        exit(1)
 
 
 if __name__ == '__main__':

--- a/practicum_4_herkansing_student.py
+++ b/practicum_4_herkansing_student.py
@@ -259,7 +259,11 @@ def __main():
 
     except AssertionError as ae:
         print("\x1b[31m")   # Rode tekstkleur
-        print(ae)
+        if len(str(ae)) == 0:
+            print("Je code veroorzaakt een AssertionError!")
+            raise ae
+        else:
+            print(ae)
 
     print("\x1b[0m")    # Reset tekstkleur
 

--- a/recursie_student.py
+++ b/recursie_student.py
@@ -133,3 +133,4 @@ if __name__ == '__main__':
             raise ae
         else:
             print(ae)
+        exit(1)

--- a/recursie_student.py
+++ b/recursie_student.py
@@ -128,4 +128,8 @@ if __name__ == '__main__':
 
     except AssertionError as ae:
         print("\x1b[31m")
-        print(ae)
+        if len(str(ae)) == 0:
+            print("Je code veroorzaakt een AssertionError!")
+            raise ae
+        else:
+            print(ae)

--- a/search_student.py
+++ b/search_student.py
@@ -223,4 +223,8 @@ if __name__ == '__main__':
 
     except AssertionError as ae:
         print("\x1b[31m")
-        print(ae)
+        if len(str(ae)) == 0:
+            print("Je code veroorzaakt een AssertionError!")
+            raise ae
+        else:
+            print(ae)

--- a/search_student.py
+++ b/search_student.py
@@ -228,3 +228,4 @@ if __name__ == '__main__':
             raise ae
         else:
             print(ae)
+        exit(1)

--- a/selection_sort_student.py
+++ b/selection_sort_student.py
@@ -117,4 +117,8 @@ if __name__ == '__main__':
 
     except AssertionError as ae:
         print("\x1b[31m")
-        print(ae)
+        if len(str(ae)) == 0:
+            print("Je code veroorzaakt een AssertionError!")
+            raise ae
+        else:
+            print(ae)

--- a/selection_sort_student.py
+++ b/selection_sort_student.py
@@ -122,3 +122,4 @@ if __name__ == '__main__':
             raise ae
         else:
             print(ae)
+        exit(1)


### PR DESCRIPTION
# Changes
Because all asserts in the test code have a message, we can assume that all the asserts with no message are thrown by user code, and we should print an appropriate warning and a stacktrace.

I also added an exit(1) if an AssertionError is thrown, and removed the `print("\x1b[0m")` to reset the text color, because that's only done in practicum files, and not in the other files. (Though maybe it *should* be done everywhere.)

# Motivation
I implemented add_frac with some asserts in my code. These asserts failed, because I was doing these assignments before they were explained in class, and I used an incorrect approach that I made up. However, I didn't notice this because the program exits with no message if an AssertionError is thrown and it doesn't have a message. I only discovered this problem because I later tried to use the same code to do my homework for me, and it didn't work.

# Note
Since this PR will be adapted to a private repository which is used to generate the code in this repository, consider using `git commit --author "Dirk Kok <the@dirkkok.nl>`" to commit your changes to this repository. Or perhaps you could:

- Check out my fork
- Run the tool in there
- Commit any extra changes on top of mine
- Merge the changes into this repository.

That way, my gpg signature will be preserved.

I have enabled the option that lets you push commits to my repo (on the branch relevant to this PR), so you could simply push any extra changes and accept this PR. 